### PR TITLE
Fixing a naming convention bug

### DIFF
--- a/Controller/Component/AnalyticsComponent.php
+++ b/Controller/Component/AnalyticsComponent.php
@@ -18,7 +18,7 @@
  
 #App::uses('FB', 'Facebook.Lib');
 #App::uses('FacebookInfo', 'Facebook.Lib');
-App::import('Vendor', 'Gapi.gapi',
+App::import('Vendor', 'Analytics.Gapi',
   array(
     'file' => 'gapi.class.php'
   )


### PR DESCRIPTION
CakePHP 2.x expects plugins to load files using the plugin folder as the prefix.

Since this plugin is in app/Plugin/Analytics it needs to load the Gapi vendor using Analytics.Gapi
