### PR TITLE
Fixed a bug casting array of results in to a string

### DIFF
--- a/Controller/Component/AnalyticsComponent.php
+++ b/Controller/Component/AnalyticsComponent.php
@@ -92,9 +92,9 @@ class AnalyticsComponent extends Component {
 
       foreach($ga->getResults() as $result){
         $data = array();
-        
+
           foreach($dimensions as $d){
-            $data[$d] = (string)$result;
+            $data[$d] = $result->{'get'.$d}();
               foreach($metrics as $m){
                 $data[$m] = $result->{'get'.$m}();
               }


### PR DESCRIPTION
This bug was taking an array of results and casting it in to a single string.  This made it hard to return multiple dimensions.
